### PR TITLE
Safe indexedDB tests

### DIFF
--- a/featuretest.js
+++ b/featuretest.js
@@ -132,7 +132,10 @@ function browserFeatureTest(successCallback) {
   storeSupport('SIMD.js', typeof SIMD !== 'undefined');
   storeSupport('Web Workers', typeof Worker !== 'undefined');
   storeSupport('Gamepad API', navigator.getGamepads || navigator.webkitGetGamepads);
-  storeSupport('IndexedDB', typeof indexedDB !== 'undefined');
+  var hasIndexedDB = false;
+  try { hasIndexedDB = typeof indexedDB !== 'undefined'; }
+  catch (e) { hasIndexedDB = false; }
+  storeSupport('IndexedDB', hasIndexedDB);
   storeSupport('Visibility API', typeof document.visibilityState !== 'undefined' || typeof document.hidden !== 'undefined');
   storeSupport('requestAnimationFrame()', typeof requestAnimationFrame !== 'undefined');
   storeSupport('performance.now()', typeof performance !== 'undefined' && performance.now);


### PR DESCRIPTION
When cookies are disabled on Firefox  for a particular site (or all sites) then test  `typeof indexedDB` throws an Exception `The operation is insecure`.

Please note that if Firefox has been launched in a private mode, an old implementation still worked in our test case. 
